### PR TITLE
Support for MDC Unique Views endpoint added

### DIFF
--- a/src/apiquery.py
+++ b/src/apiquery.py
@@ -719,3 +719,75 @@ class DataverseCollectionDownloadsMonthly(DataverseMetricsAPIQuery):
             'reason': r.reason,
             'data': r.json()['data']
         }
+    
+class DataverseMDCUniqueViews(DataverseMetricsAPIQuery):
+    """
+    Retrieve Make Data Count unique dataset views
+
+    See: https://guides.dataverse.org/en/latest/api/native-api.html#retrieving-unique-views-for-a-dataset
+
+    Endpoint: api/datasets/:persistentId/makeDataCount/viewsUnique?persistentId=$PERSISTENT_ID
+    """
+    def __init__(self, server, **kwargs):
+        super().__init__(server)
+        self._parameters = {
+            'persistentId': kwargs.get('persistentId', None)
+        }
+
+    @property
+    def endpoint(self) -> str:
+        return f'api/datasets/:persistentId/makeDataCount/viewsUnique'
+
+    @property
+    def parameters(self):
+        return self._parameters
+    
+    @parameters.setter
+    def parameters(self, params : dict):
+        """
+        Set API parameters
+
+        Parameter
+        ---------
+        params : dict
+        """
+        for key in params.keys():
+            if not key in self._parameters.keys():
+                raise Exception(f'Invalid parameter: {key}')
+            self._parameters[key] = params[key]
+
+    def execute(self, api_token: str) -> dict:
+        """
+        Query api
+
+        Return
+        ------
+        dict: 
+            {'status_code': code, 'data':{data}}
+            data fields:
+                count, date
+        """
+        if not self.validate_parameters():
+            raise Exception(f'Invalid parameter value in: {self._parameters}')
+        
+        headers = {}
+        headers['Accept'] = 'application/json'
+        headers['X-Dataverse-key'] = api_token
+
+        payload = self._parameters
+        request_url = f'{self.server_url}/{self.endpoint}'
+
+        r = requests.get(request_url, headers=headers, params=payload)
+
+        if not r.status_code == requests.codes.ok:
+            return {
+                'status_code':r.status_code,
+                'reason': r.reason,
+                'data': {}
+            }
+        
+        return {
+            'status_code':r.status_code,
+            'reason': r.reason,
+            'data': r.json()['data']
+        }

--- a/test/test_mdcuniqueviews.py
+++ b/test/test_mdcuniqueviews.py
@@ -1,0 +1,30 @@
+import os
+from apiquery import DataverseMDCUniqueViews
+
+class  TestDataverseMDCUniqueViews:
+
+    def test_succeed(self):
+
+        api_token = os.getenv('DATAVERSE_API_TOKEN')
+        server = os.getenv('DV_SERVER')
+        dataset_id = os.getenv('DV_DATASET_ID') # e.g, doi:10.7910/DVN/9STGWE
+
+        if not api_token:
+            raise Exception('Environment variable: "DATAVERSE_API_TOKEN" is not set')
+        
+        if not server: 
+            raise Exception('Environment variable: "DV_SERVER" is not set')
+        
+        if not dataset_id: 
+            raise Exception('Environment variable: "DV_DATASET_ID" is not set')
+        
+        query = DataverseMDCUniqueViews(server, persistentId=dataset_id)
+        
+        results = query.execute(api_token)
+
+        status_code = results.get('status_code')
+        data = results.get('data', {})
+
+        result = True if len(data) > 0 and status_code == 200 else False
+
+        assert result == True


### PR DESCRIPTION
Added support for the Make Data Count unique dataset views API endpoint:

  See: https://guides.dataverse.org/en/latest/api/native-api.html#retrieving-unique-views-for-a-dataset